### PR TITLE
feat: set border style from config

### DIFF
--- a/lua/lazydocker/config.lua
+++ b/lua/lazydocker/config.lua
@@ -2,7 +2,9 @@ local constants = require("lazydocker.utils.constants")
 local state = require("lazydocker.state")
 
 local M = {
-	__DEFAULT_OPTIONS = {},
+	__DEFAULT_OPTIONS = {
+		border = "double",
+	},
 }
 
 -- Initialize default options

--- a/lua/lazydocker/ui.lua
+++ b/lua/lazydocker/ui.lua
@@ -1,4 +1,5 @@
 local Terminal = require("toggleterm.terminal").Terminal
+local lazydocker_config = require("lazydocker.config")
 
 local M = {}
 
@@ -16,7 +17,7 @@ function M.toggle_lazydocker_terminal()
 		lazydocker_term = Terminal:new({
 			cmd = "lazydocker",
 			direction = "float",
-			float_opts = { border = "double" },
+			float_opts = { border = lazydocker_config.options.border },
 			on_open = function(term)
 				vim.cmd("startinsert!")
 				vim.api.nvim_buf_set_keymap(term.bufnr, "n", "q", "<cmd>close<CR>", { noremap = true, silent = true })


### PR DESCRIPTION
Removed hard-coded border style, and allows it to be configurable.
The default is `double`, as it currently is.